### PR TITLE
i am doing timestamp hacking in here

### DIFF
--- a/vcr_lib/src/feed/event.rs
+++ b/vcr_lib/src/feed/event.rs
@@ -45,11 +45,18 @@ pub struct CompactedFeedEvent {
 }
 
 impl FeedEvent {
-    pub fn generate_id(&self) -> Vec<u8> {
+    pub fn generate_id(&self, millis_epoch: Option<u32>) -> Vec<u8> {
+        let timestamp = match millis_epoch {
+            Some(epoch) => {
+                let epoch = (epoch as i64) * 1000;
+                (self.created.timestamp_millis() - epoch) as u32
+            }
+            None => self.created.timestamp() as u32,
+        };
         [
             self.season.to_be_bytes().to_vec(),
             self.phase.to_be_bytes().to_vec(),
-            (self.created.timestamp() as u32).to_be_bytes().to_vec(),
+            timestamp.to_be_bytes().to_vec(),
             self.id.as_bytes()[0..2].to_vec(),
         ]
         .concat()


### PR DESCRIPTION
**i have not tested this at all**

this will store millisecond-resolution timestamps, while only using 228 more bytes for an additional index, for events in expansion era phases 3, 5, and 13 (earlsiesta, latesiesta, and election), where events happen relatively quickly one after another and ordering is important. it does this by determining a local epoch (the start of the hour) for each phase and recording the number of milliseconds since that local epoch.